### PR TITLE
Mark `grunt-xsltproc` as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   },
   "author": "Pierre-Henri Trivier <phtrivier@yahoo.fr>",
   "license": "MIT",
-  "devDependencies": {
-    "grunt": "^0.4.5",
+  "dependencies": {
     "grunt-xsltproc": "^0.4.0"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5"
   }
 }


### PR DESCRIPTION
Fixes #2
